### PR TITLE
Bug fix for issue #9: Missing progress events

### DIFF
--- a/src/FFmpeg.NET/RegexEngine.cs
+++ b/src/FFmpeg.NET/RegexEngine.cs
@@ -50,7 +50,7 @@ namespace FFmpeg.NET
             var matchTime = _index[Find.ConvertProgressTime].Match(data);
             var matchBitrate = _index[Find.ConvertProgressBitrate].Match(data);
 
-            if (!matchSize.Success || !matchTime.Success || !matchBitrate.Success)
+            if (!matchTime.Success)
                 return false;
 
             TimeSpan.TryParse(matchTime.Groups[1].Value, out var processedDuration);

--- a/tests/FFmpeg.NET.Tests/ConversionTests.cs
+++ b/tests/FFmpeg.NET.Tests/ConversionTests.cs
@@ -59,5 +59,32 @@ namespace FFmpeg.NET.Tests
             Assert.Equal(output, e.Arguments.Output);
             Assert.Equal(1, e.Arguments.Exception.ExitCode);
         }
+
+        [Fact]
+        public async Task FFmpeg_Invokes_ProgressEvent_With_Segment_Option()
+        {
+            Engine ffmpeg = new Engine(_fixture.FFmpegPath);
+
+            // Progress messages from ffmpeg usually look like this:
+            //      size=       0kB time=-577014:32:22.77 bitrate=N/A speed=N/
+            // But when some options (such as -f segment) are used, you do not get the bitrate 
+            // and size.  In this case you will see
+            //      size=N/A time=00:11:00.11 bitrate=N/A speed=1.32e+03x
+            // Test for this case using -f segment option.
+            // Concatenate two copies of the sample audio file together to make sure the input is long enough
+            // to generate progress messages. Split the result into 20 second segments. 
+            string fn = $"-i \"{_fixture.AudioFile.FileInfo.FullName}\"";
+            string options = $"{fn} {fn} -filter_complex \"[0:0][1:0]concat=n=2:v=0:a=1[out]\" -map \"[out]\" -f segment -segment_time 20 Split%1d.mp3";
+
+            var e = await Assert.RaisesAsync<ConversionProgressEventArgs>(
+                x => ffmpeg.Progress += x,
+                x => ffmpeg.Progress -= x,
+                async () => await ffmpeg.ExecuteAsync(options)
+            );
+
+            File.Delete("Split0.mp3");
+            File.Delete("Split1.mp3");
+            File.Delete("Split2.mp3");
+        }
     }
 }


### PR DESCRIPTION
See https://github.com/cmxl/FFmpeg.NET/issues/9
When using some ffmpeg options (such as -f segment), ffmpeg.net was not recognizing the progress message from ffmpeg.exe, and therefore did not raise the Progress event.