### PR TITLE
Bug fix for issue #10: Files longer than 24 hours

### DIFF
--- a/src/FFmpeg.NET/FFmpegProcess.cs
+++ b/src/FFmpeg.NET/FFmpegProcess.cs
@@ -74,7 +74,7 @@ namespace FFmpeg.NET
                         if (parameters.InputFile.MetaData == null)
                             parameters.InputFile.MetaData = new MetaData { FileInfo = parameters.InputFile.FileInfo };
 
-                        TimeSpan.TryParse(matchDuration.Groups[1].Value, out totalMediaDuration);
+                        RegexEngine.TimeSpanLargeTryParse(matchDuration.Groups[1].Value, out totalMediaDuration);
                         parameters.InputFile.MetaData.Duration = totalMediaDuration;
                     }
                 }


### PR DESCRIPTION
See https://github.com/cmxl/FFmpeg.NET/issues/10
GetMetaData did not return the correct duration for files that have a duration longer than 24 hours. And Progress events stopped occurring after processing 24 hours.