### PR TITLE
* Bug fix for issue #14: Duplicate error events

### DIFF
--- a/src/FFmpeg.NET/FFmpegProcess.cs
+++ b/src/FFmpeg.NET/FFmpegProcess.cs
@@ -29,7 +29,7 @@ namespace FFmpeg.NET
                 ffmpegProcess.ErrorDataReceived += (sender, e) => OnData(new ConversionDataEventArgs(e.Data, parameters.InputFile, parameters.OutputFile));
                 ffmpegProcess.ErrorDataReceived += (sender, e) => FFmpegProcessOnErrorDataReceived(e, parameters, ref caughtException, messages);
 
-                await ffmpegProcess.WaitForExitAsync((exitCode) => OnException(messages, parameters, exitCode, caughtException), cancellationToken);
+                await ffmpegProcess.WaitForExitAsync(null, cancellationToken);
 
                 if (caughtException != null || ffmpegProcess.ExitCode != 0)
                 {


### PR DESCRIPTION
See https://github.com/cmxl/FFmpeg.NET/issues/14
When ffmpeg.exe reports an error (via a non-zero exit code), this library raised the Error event twice with the same message. Changed to only raise the event once.