### PR TITLE
Fixed parsing error in metaData.Duration

### DIFF
--- a/src/FFmpeg.NET/RegexEngine.cs
+++ b/src/FFmpeg.NET/RegexEngine.cs
@@ -92,7 +92,8 @@ namespace FFmpeg.NET
             // Process seconds
             double seconds = 0.0;
             start = end + 1;
-            if (!double.TryParse(str.Substring(start), out seconds))
+            // ffmpeg doesnt respect the computers culture
+            if (!double.TryParse(str.Substring(start), NumberStyles.Number, CultureInfo.InvariantCulture, out seconds))
                 return false;
 
             result = new TimeSpan(0, hours, minutes, 0, (int)Math.Round(seconds * 1000.0));

--- a/tests/FFmpeg.NET.Tests/MetadataTests.cs
+++ b/tests/FFmpeg.NET.Tests/MetadataTests.cs
@@ -100,6 +100,8 @@ namespace FFmpeg.NET.Tests
             Assert.Equal("48000 Hz", metaData.AudioData.SampleRate);
             Assert.Equal("5.1", metaData.AudioData.ChannelOutput);
             Assert.Equal(384, metaData.AudioData.BitRateKbs);
+
+            Assert.Equal(metaData.Duration, new TimeSpan(0, 0, 0, 5, 310));
         }
 
         [Fact]


### PR DESCRIPTION
ffmpeg doesn't respect the culture of the client. Therefor parsing the duration of for example 00:05.31 on a german machine resulted in 531 seconds instead of 5 seconds and 310 ms. Fixed it by using InvariantCulture where the decimal point is always a point and not a comma.
