### PR TITLE
Force flush output/error stream before task completion, solves #25

### DIFF
--- a/src/FFmpeg.NET/Extensions/ProcessExtensions.cs
+++ b/src/FFmpeg.NET/Extensions/ProcessExtensions.cs
@@ -41,6 +41,7 @@ namespace FFmpeg.NET.Extensions
             process.EnableRaisingEvents = true;
             process.Exited += (sender, e) =>
             {
+                process.WaitForExit();
                 if (process.ExitCode != 0)
                     onException?.Invoke(process.ExitCode);
                 tcs.TrySetResult(process.ExitCode);


### PR DESCRIPTION
Should solve issue #25 