### PR TITLE
Allow overload in Engine ctor and fix null exception

### DIFF
--- a/src/FFmpeg.NET/Engine.cs
+++ b/src/FFmpeg.NET/Engine.cs
@@ -13,10 +13,10 @@ namespace FFmpeg.NET
         /// <summary>
         /// Instantiate the FFmpeg engine by providing either the name of the executable or the path to the executable. If only file name is provided, it must be found through the PATH variables.
         /// </summary>
-        /// <param name="ffmpegPath">The path to the ffmpeg executable, or the executable if it is defined in PATH</param>
-        public Engine(string ffmpegPath)
+        /// <param name="ffmpegPath">The path to the ffmpeg executable, or the executable if it is defined in PATH. If left empty, it will try to find "ffmpeg.exe" from PATH.</param>
+        public Engine(string ffmpegPath = null)
         {
-            _ffmpegPath = ffmpegPath ?? throw new ArgumentNullException(ffmpegPath, "FFmpeg executable path needs to be provided.");
+            ffmpegPath = ffmpegPath ?? "ffmpeg.exe";
 
             if (!ffmpegPath.TryGetFullPath(out _ffmpegPath))
                 throw new ArgumentException(ffmpegPath, "FFmpeg executable could not be found neither in PATH nor in directory.");

--- a/src/FFmpeg.NET/Engine.cs
+++ b/src/FFmpeg.NET/Engine.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using FFmpeg.NET.Extensions;
 
 namespace FFmpeg.NET
 {
@@ -9,9 +10,16 @@ namespace FFmpeg.NET
     {
         private readonly string _ffmpegPath;
 
+        /// <summary>
+        /// Instantiate the FFmpeg engine by providing either the name of the executable or the path to the executable. If only file name is provided, it must be found through the PATH variables.
+        /// </summary>
+        /// <param name="ffmpegPath">The path to the ffmpeg executable, or the executable if it is defined in PATH</param>
         public Engine(string ffmpegPath)
         {
             _ffmpegPath = ffmpegPath ?? throw new ArgumentNullException(ffmpegPath, "FFmpeg executable path needs to be provided.");
+
+            if (!ffmpegPath.TryGetFullPath(out _ffmpegPath))
+                throw new ArgumentException(ffmpegPath, "FFmpeg executable could not be found neither in PATH nor in directory.");
         }
 
         public event EventHandler<ConversionProgressEventArgs> Progress;

--- a/src/FFmpeg.NET/Extensions/StringExtensions.cs
+++ b/src/FFmpeg.NET/Extensions/StringExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.IO;
+
+namespace FFmpeg.NET.Extensions
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Check if the string value equals a path to a file using File.Exists
+        /// </summary>
+        /// <param name="filePath">The full path to the file to check</param>
+        /// <param name="fullPath">The verified full path. If file does not exist, it returns string.Empty.</param>
+        /// <returns></returns>
+        public static bool TryGetFullPathIfFileExists(this string filePath, out string fullPath)
+        {
+            fullPath = string.Empty;
+
+            if (!File.Exists(filePath)) return false;
+
+            fullPath = Path.GetFullPath(filePath);
+            return true;
+        }
+
+        /// <summary>
+        /// Check if the string value equals a path to a file using the PATH environment variables
+        /// </summary>
+        /// <param name="fileName">The filename to check if exists in path variables</param>
+        /// <param name="fullPath">The verified full path. If file does not exist, it returns string.Empty.</param>
+        /// <returns></returns>
+        public static bool TryGetFullPathIfPathEnvironmentExists(this string fileName, out string fullPath)
+        {
+            fullPath = string.Empty;
+            var values = Environment.GetEnvironmentVariable("PATH");
+            var pathElements = values?.Split(Path.PathSeparator);
+
+            if (pathElements == null) return false;
+
+            foreach (var path in pathElements)
+            {
+                var tempFullPath = Path.Combine(path, fileName);
+                if (tempFullPath.TryGetFullPathIfFileExists(out fullPath))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check if a file or file path exists or if the file can be found through the PATH variables.
+        /// </summary>
+        /// <param name="file">The file name or file path to check</param>
+        /// <param name="fullPath">The verified full path. If file does not exist, it returns string.Empty.</param>
+        /// <returns></returns>
+        public static bool TryGetFullPath(this string file, out string fullPath)
+        {
+            if (file.TryGetFullPathIfFileExists(out fullPath)) return true;
+            if (file.TryGetFullPathIfPathEnvironmentExists(out fullPath)) return true;
+
+            return false;
+        }
+    }
+}

--- a/src/FFmpeg.NET/FFmpegProcess.cs
+++ b/src/FFmpeg.NET/FFmpegProcess.cs
@@ -98,7 +98,11 @@ namespace FFmpeg.NET
 
                 if (RegexEngine.IsProgressData(e.Data, out var progressData))
                 {
-                    progressData.TotalDuration = parameters.InputFile.MetaData?.Duration ?? totalMediaDuration;
+                    if (parameters.InputFile != null)
+                    {
+                        progressData.TotalDuration = parameters.InputFile.MetaData?.Duration ?? totalMediaDuration;
+                    }
+
                     OnProgressChanged(new ConversionProgressEventArgs(progressData, parameters.InputFile, parameters.OutputFile));
                 }
             }

--- a/tests/FFmpeg.NET.Tests/StringExtensionsTest.cs
+++ b/tests/FFmpeg.NET.Tests/StringExtensionsTest.cs
@@ -1,0 +1,120 @@
+﻿using FFmpeg.NET.Services;
+using FFmpeg.NET.Tests.Fixtures;
+using System;
+using System.IO;
+using System.Linq;
+using FFmpeg.NET.Extensions;
+using Microsoft.DotNet.PlatformAbstractions;
+using Xunit;
+
+namespace FFmpeg.NET.Tests
+{
+    public class StringExtensionsTest
+    {
+        [Fact]
+        public void Should_Get_FileExists_True_On_This_File()
+        {
+            // Arrange
+            var testFolder = GetTestFolder();
+            var thisFile = Path.Combine(testFolder, nameof(StringExtensionsTest) + ".cs");
+
+            // Act
+            var fileExists = File.Exists(thisFile);
+
+            // Assert
+            Assert.True(fileExists);
+        }
+
+        [Fact]
+        public void Should_Get_FullPath_To_Existing_File()
+        {
+            // Arrange
+            var testFolder = GetTestFolder();
+            var thisFile = Path.Combine(testFolder, nameof(StringExtensionsTest) + ".cs");
+
+            // Act
+            var fileExists = thisFile.TryGetFullPath(out var fullPath);
+            var fileExistsVerified = File.Exists(fullPath);
+
+            // Assert
+            Assert.True(fileExists);
+            Assert.True(fileExistsVerified);
+        }
+
+        [Fact]
+        public void Should_Not_Get_FullPath_To_NonExisting_File()
+        {
+            // Arrange
+            var testFolder = GetTestFolder();
+            var bogusFile = Path.Combine(testFolder, "bogusFile.txt");
+
+            // Act
+            var fileExists = bogusFile.TryGetFullPath(out var fullPath);
+            var fileExistsVerified = File.Exists(fullPath);
+
+            // Assert
+            Assert.False(fileExists);
+            Assert.False(fileExistsVerified);
+        }
+
+        [Fact]
+        public void Should_Get_FullPath_When_Directory_Is_In_Path()
+        {
+            // Arrange
+            var testFolder = GetTestFolder();
+            var testFileName = "existsInPathEnvFile.deleteMe";
+            var testFileFullPath = Path.Combine(testFolder, testFileName);
+            var pathVariable = System.Environment.GetEnvironmentVariable("PATH");
+            var newPathVariable = pathVariable + $";{testFolder}";
+            var target = EnvironmentVariableTarget.Process;
+
+            Environment.SetEnvironmentVariable("PATH", newPathVariable, target);
+            using (File.Create(testFileFullPath)) { }
+
+            // Act
+            var fileExists = testFileName.TryGetFullPath(out var fullPath);
+            var fileExistsVerified = File.Exists(fullPath);
+
+            // Cleanup
+            Environment.SetEnvironmentVariable("PATH", pathVariable, target);
+            File.Delete(testFileFullPath);
+
+            // Assert
+            Assert.True(fileExists);
+            Assert.True(fileExistsVerified);
+        }
+
+        [Fact]
+        public void Should_Not_Get_FullPath_When_Directory_Is__In_Path_But_File_Is_Not()
+        {
+            // Arrange
+            var testFolder = GetTestFolder();
+            var testFileName = "notInPathEnvFile.txt";
+            var orgPathVariable = Environment.GetEnvironmentVariable("PATH");
+            var newPathVariable = orgPathVariable + $";{testFolder}";
+            var target = EnvironmentVariableTarget.Process;
+
+            Environment.SetEnvironmentVariable("PATH", newPathVariable, target);
+
+            // Act
+            var fileExists = testFileName.TryGetFullPath(out var fullPath);
+            var fileExistsVerified = File.Exists(fullPath);
+
+            // Cleanup
+            Environment.SetEnvironmentVariable("PATH", orgPathVariable, target);
+
+            // Assert
+            Assert.False(fileExists);
+            Assert.False(fileExistsVerified);
+        }
+
+        private static string GetTestFolder()
+        {
+            var startupPath = ApplicationEnvironment.ApplicationBasePath;
+            var pathItems = startupPath.Split(Path.DirectorySeparatorChar);
+            var pos = pathItems.Reverse().ToList().FindIndex(x => string.Equals("bin", x));
+            var projectPath = string.Join(Path.DirectorySeparatorChar.ToString(), pathItems.Take(pathItems.Length - pos - 1));
+            return projectPath;
+        }
+    }
+}


### PR DESCRIPTION
*Add Engine ctor overload and null checking*

> This PR fixes a NULL exception discovered by the tests. Also added two small tests on the Progress event and Data event.

* Add the option to have empty Engine constructor. Looks for ffmpeg.exe in PATH if not defined in input.
* Check if InputFile is null when checking for file TotalDuration