### PR TITLE
Correct Video Bit Rate flag to -b:v to fix error.

### DIFF
--- a/src/FFmpeg.NET/FFmpegArgumentBuilder.cs
+++ b/src/FFmpeg.NET/FFmpegArgumentBuilder.cs
@@ -95,7 +95,7 @@ namespace FFmpeg.NET
 
             // Video bit rate
             if (conversionOptions.VideoBitRate != null)
-                commandBuilder.AppendFormat(" -b {0}k ", conversionOptions.VideoBitRate);
+                commandBuilder.AppendFormat(" -b:v {0}k ", conversionOptions.VideoBitRate);
 
             // Video frame rate
             if (conversionOptions.VideoFps != null)


### PR DESCRIPTION
Simple addition to resolve error if using a Video Bit Rate value.