### PR TITLE
Support `-pix_fmt` argument

### DIFF
--- a/src/FFmpeg.NET/ConversionOptions.cs
+++ b/src/FFmpeg.NET/ConversionOptions.cs
@@ -52,6 +52,11 @@ namespace FFmpeg.NET
         public int? VideoFps { get; set; } = null;
 
         /// <summary>
+        ///     Pixel format. Available formats can be gathered via `ffmpeg -pix_fmts`.
+        /// </summary>
+        public string PixelFormat { get; set; } = null;
+
+        /// <summary>
         ///     Video sizes
         /// </summary>
         public VideoSize VideoSize { get; set; } = VideoSize.Default;

--- a/src/FFmpeg.NET/FFmpegArgumentBuilder.cs
+++ b/src/FFmpeg.NET/FFmpegArgumentBuilder.cs
@@ -101,6 +101,10 @@ namespace FFmpeg.NET
             if (conversionOptions.VideoFps != null)
                 commandBuilder.AppendFormat(" -r {0} ", conversionOptions.VideoFps);
 
+            // Video pixel format
+            if (conversionOptions.PixelFormat != null)
+                commandBuilder.AppendFormat(" -pix_fmt {0} ", conversionOptions.PixelFormat);
+
             // Video size / resolution
             commandBuilder = AppendVideoSize(commandBuilder, conversionOptions);
 


### PR DESCRIPTION
This argument is needed to support Android devices. `ffmpeg` uses `h264 (High 4:4:4 Predictive)` profile by default and the converted video file is not played on Android devices. I deliberately did not create an Enum with all possible formats, since there are a lot of them and their number depends on the compile flags of `ffmpeg`.