### PR TITLE
add extra arguments for convert options

### DIFF
--- a/src/FFmpeg.NET/ConversionOptions.cs
+++ b/src/FFmpeg.NET/ConversionOptions.cs
@@ -67,6 +67,11 @@ namespace FFmpeg.NET
         public int? CustomHeight { get; set; }
 
         /// <summary>
+        ///     Extra Arguments, such as  -movflags +faststart. Can be used to support missing features temporary
+        /// </summary>
+        public string ExtraArguments { get; set; }
+
+        /// <summary>
         ///     Specifies an optional rectangle from the source video to crop
         /// </summary>
         public CropRectangle SourceCrop { get; set; }

--- a/src/FFmpeg.NET/FFmpegArgumentBuilder.cs
+++ b/src/FFmpeg.NET/FFmpegArgumentBuilder.cs
@@ -110,6 +110,10 @@ namespace FFmpeg.NET
             // Video cropping
             commandBuilder = AppendVideoCropping(commandBuilder, conversionOptions);
 
+            // Extra arguments
+            if (conversionOptions.ExtraArguments != null)
+                commandBuilder.AppendFormat(" {0} ", conversionOptions.ExtraArguments);
+
             if (conversionOptions.BaselineProfile)
                 commandBuilder.Append(" -profile:v baseline ");
 


### PR DESCRIPTION
Sometimes user may ask for some featrues in hurry, I add the extra arguments in convert options so they can put arguments by themself before the new feature come (or never :grinning: ).