### PR TITLE
Support for totalDuration metadata from network inputs  

### DIFF
--- a/src/FFmpeg.NET/Events/ConversionProgressEventArgs.cs
+++ b/src/FFmpeg.NET/Events/ConversionProgressEventArgs.cs
@@ -5,7 +5,7 @@ namespace FFmpeg.NET.Events
 {
     public class ConversionProgressEventArgs : EventArgs
     {
-        internal ConversionProgressEventArgs(ProgressData progressData, IInputArgument input, IOutputArgument output)
+        internal ConversionProgressEventArgs(ProgressData progressData, IInputArgument input, IOutputArgument output, MediaInfo mediaInfo)
         {
             Input = input;
             Output = output;
@@ -15,6 +15,7 @@ namespace FFmpeg.NET.Events
             Fps = progressData.Fps;
             SizeKb = progressData.SizeKb;
             Bitrate = progressData.Bitrate;
+            MediaInfo = mediaInfo;
         }
 
         public long? Frame { get; }
@@ -25,6 +26,7 @@ namespace FFmpeg.NET.Events
         public TimeSpan TotalDuration { get; }
         public IOutputArgument Output { get; }
         public IInputArgument Input { get; }
+        public MediaInfo MediaInfo{ get; }
 
         public override string ToString()
             => $"[{Input?.Name} => {Output?.Name}]\nFrame: {Frame}\nFps: {Fps}\nSize: {SizeKb}kb\nProcessedDuration: {ProcessedDuration}\nBitrate: {Bitrate}\nTotalDuration: {TotalDuration}";

--- a/src/FFmpeg.NET/FFmpegProcess.cs
+++ b/src/FFmpeg.NET/FFmpegProcess.cs
@@ -81,7 +81,6 @@ namespace FFmpeg.NET
         private void OnDataHandler(object sender, DataReceivedEventArgs e)
         {
             OnData(new ConversionDataEventArgs(e.Data, parameters.Input, parameters.Output));
-            tryUpdateMediaInfo(e.Data);
             FFmpegProcessOnErrorDataReceived(e, parameters, ref caughtException, messages);
         }
         private void tryUpdateMediaInfo (String data){
@@ -111,6 +110,7 @@ namespace FFmpeg.NET
 
             try
             {
+                tryUpdateMediaInfo(e.Data);
                 messages.Insert(0, e.Data);
                 if (parameters.Input != null)
                 {

--- a/src/FFmpeg.NET/Models/MediaInfo.cs
+++ b/src/FFmpeg.NET/Models/MediaInfo.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FFmpeg.NET.Models
+{
+    public class MediaInfo
+    {
+        public MediaInfo( double bitrate, TimeSpan totalDuration)
+        {
+    
+            Bitrate = bitrate;
+            TotalDuration = totalDuration;
+        }
+
+        public double Bitrate { get; }
+        public TimeSpan TotalDuration { get; internal set; }
+
+    }
+}

--- a/src/FFmpeg.NET/RegexEngine.cs
+++ b/src/FFmpeg.NET/RegexEngine.cs
@@ -69,7 +69,7 @@ namespace FFmpeg.NET
         {
             mediaInfo = null;
 
-
+            if(data==null||data=="") return false;
             var matchBitrate = _index[Find.BitRate].Match(data);
             var matchDuration = _index[Find.Duration].Match(data);
             


### PR DESCRIPTION
## Description:
Include in the **OnProgressChanged** event args an object containing data supplied by ffmpeg's **startup** logging, Specifically this line :
```
Duration: 00:05:34.08, start: 0.000000, bitrate: 1530 kb/s 
```
The MediaInfo replaces the current **totalDuration** value that doesn't work much of the time.
The current value reports 00:00:00 when the source is accessed by ftp/http or when the engine is started using custom args by calling **Execute**
I am unsure if my technique of getting the data from the ffmpeg stdout logging has any downsides, but as far as I can see it works well.

Perhaps MediaInfo should be renamed to ClipInfo? Thoughts?

