### PR TITLE
"Bug" fixed that FFmpeg with the CancellationToken doesn't always exit.

### DIFF
--- a/src/FFmpeg.NET/FFmpegProcess.cs
+++ b/src/FFmpeg.NET/FFmpegProcess.cs
@@ -52,6 +52,8 @@ namespace FFmpeg.NET
                 // task.IsCanceled will be true.
                 if (task.IsCanceled)
                 {
+                    if (!ffmpegProcess.HasExited)
+                        ffmpegProcess.Kill();
                     throw new TaskCanceledException(task);
                 }
                 // I don't think this can occur, but if some other exception, rethrow it.


### PR DESCRIPTION
If you call Cancel() on the CancellationTokenSource and pass the CancellationToken to a Task like Engine.ExecuteAsync(string arguments, CancellationToken cancellationToken), ffmpeg.exe is not always terminated. Now it is checked whether the process is still running and if so, ffmpeg.exe will be terminated. 

I'm new to GitHub. For my use case, this fix works. I only tested it in my scenario and recommend to test it again before merging. Please do not merge this pull request if the current behavior is intended to cancel only the task itself and dont kill the ffmpeg.exe process.