### PR TITLE
Dump output stream of ffmpeg

### DIFF
--- a/src/FFmpeg.NET/Extensions/ProcessExtensions.cs
+++ b/src/FFmpeg.NET/Extensions/ProcessExtensions.cs
@@ -67,6 +67,7 @@ namespace FFmpeg.NET.Extensions
             if (!started)
                 tcs.TrySetException(new InvalidOperationException($"Could not start process {process}"));
 
+            process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
             return tcs.Task;


### PR DESCRIPTION
[Right here](https://github.com/cmxl/FFmpeg.NET/blob/9ea10600f2ee4dc4a50c7ecfc11e925a75ab513a/src/FFmpeg.NET/FFmpegProcess.cs#L175C1-L175C28) you are redirecting output, but when starting the process you are only reading error stream.
I had a case where `.GetMetaDataAsync` hanged with ffmpeg process using 0 CPU.
My guess is that the output buffer backed up and was waiting for something to read it, so the process couldn't exit properly.
It was very specific to one video, probably because it was downloaded [from yt](https://www.youtube.com/watch?v=ffEnHsmGfdo) and had a huge description attached to it, which filled the output buffer.

Not sure if adding `.BeginOutputReadLine` is the best solution... It works for me, for now at least. If you have any better idea - please treat this pull as if it's an issue report.