### PR TITLE
Add parameter to set `startInfo.WorkingDirectory`

### DIFF
--- a/src/FFmpeg.NET/Engine.cs
+++ b/src/FFmpeg.NET/Engine.cs
@@ -143,12 +143,12 @@ namespace FFmpeg.NET
             Cleanup(ffmpegProcess);
         }
 
-        public async Task ExecuteAsync(string arguments, CancellationToken cancellationToken)
+        public async Task ExecuteAsync(string arguments, CancellationToken cancellationToken, string currentDir = null)
         {
             var parameters = new FFmpegParameters
             {
                 CustomArguments = arguments,
-
+                CurrentDir = currentDir
             };
             await ExecuteAsync(parameters, cancellationToken).ConfigureAwait(false);
         }

--- a/src/FFmpeg.NET/FFmpegParameters.cs
+++ b/src/FFmpeg.NET/FFmpegParameters.cs
@@ -4,6 +4,7 @@
     {
         public bool HasCustomArguments => !string.IsNullOrWhiteSpace(CustomArguments);
         public string CustomArguments { get; set; }
+        public string CurrentDir { get; set; }
         public ConversionOptions ConversionOptions { get; set; }
         public FFmpegTask Task { get; set; }
         public IOutputArgument Output { get; set; }

--- a/src/FFmpeg.NET/FFmpegProcess.cs
+++ b/src/FFmpeg.NET/FFmpegProcess.cs
@@ -31,6 +31,7 @@ namespace FFmpeg.NET
             _caughtException = null;
             string arguments = FFmpegArgumentBuilder.Build(_parameters);
             ProcessStartInfo startInfo = GenerateStartInfo(_ffmpegFilePath, arguments);
+            startInfo.WorkingDirectory = _parameters.CurrentDir ?? "";
             await ExecuteAsync(startInfo, _parameters, cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
I need to execute this command:
```
ffmpeg -dump_attachment:t "" -i {file}
```
If I specify anything other than `""` as a path - the ffmpeg is going to try and (fail to) save all attachments into the same file.
And `%d` doesn't seem to be supported here...
The best solution I found is to set the working dir to a new empty folder, so as to not mix the output of this command with other files. But there doesn't seem to be functionality for that in xFFmpeg.Net rn - I don't see `startInfo.WorkingDirectory` being set anywhere. 