### PR TITLE
Made ExecuteAsync method public and added overload to stream output via pipe

### DIFF
--- a/src/FFmpeg.NET/Engine.cs
+++ b/src/FFmpeg.NET/Engine.cs
@@ -31,6 +31,11 @@ namespace FFmpeg.NET
         public event EventHandler<ConversionCompleteEventArgs> Complete;
         public event EventHandler<ConversionDataEventArgs> Data;
 
+
+        // ---------------------------------------------------------
+        // Wrapper methods for ease of use
+        // ---------------------------------------------------------
+
         public async Task<MetaData> GetMetaDataAsync(IInputArgument mediaFile, CancellationToken cancellationToken)
         {
             var parameters = new FFmpegParameters
@@ -87,93 +92,82 @@ namespace FFmpeg.NET
 
         public async Task ConvertAsync(IInputArgument input, Stream output, ConversionOptions options, CancellationToken cancellationToken)
         {
-            var outputPipeName = $"{_pipePrefix}{Guid.NewGuid()}";
-            var outputArgument = new OutputPipe(GetPipePath(outputPipeName));
-            var pipe = new NamedPipeServerStream(outputPipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-
             var parameters = new FFmpegParameters
             {
                 Task = FFmpegTask.Convert,
                 Input = input,
-                Output = outputArgument,
                 ConversionOptions = options
             };
-
-            var ffmpegProcess = CreateProcess(parameters);
-            try
-            {
-                var executeProcess = ffmpegProcess.ExecuteAsync(cancellationToken);
-                var copyData = pipe.WaitForConnectionAsync(cancellationToken)
-                    .ContinueWith(async x =>
-                    {
-                        await pipe.CopyToAsync(output, cancellationToken);
-                    }, cancellationToken).Unwrap();
-                await Task.WhenAll(executeProcess, copyData).ConfigureAwait(false);
-                pipe.Disconnect();
-            }
-            finally
-            {
-                pipe.Dispose();
-                Cleanup(ffmpegProcess);
-            }
+            await ExecuteAsync(parameters, output, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task ConvertAsync(IArgument argument, Stream output, CancellationToken cancellationToken)
         {
-            var outputPipeName = $"{_pipePrefix}{Guid.NewGuid()}";
-            var outputArgument = new OutputPipe(GetPipePath(outputPipeName));
-            var pipe = new NamedPipeServerStream(outputPipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-
-            var arguments = argument.Argument + $" {outputArgument.Argument}";
-            var parameters = new FFmpegParameters { CustomArguments = arguments };
-
-            var ffmpegProcess = CreateProcess(parameters);
-            try
+            var parameters = new FFmpegParameters
             {
-                var executeProcess = ffmpegProcess.ExecuteAsync(cancellationToken);
-                var copyData = pipe.WaitForConnectionAsync(cancellationToken)
-                    .ContinueWith(async x =>
-                    {
-                        await pipe.CopyToAsync(output, cancellationToken);
-                    }, cancellationToken).Unwrap();
-                await Task.WhenAll(executeProcess, copyData).ConfigureAwait(false);
-                pipe.Disconnect();
-            }
-            finally
-            {
-                pipe.Dispose();
-                Cleanup(ffmpegProcess);
-            }
-        }
-
-        private async Task ExecuteAsync(FFmpegParameters parameters, CancellationToken cancellationToken)
-        {
-            var ffmpegProcess = CreateProcess(parameters);
-            await ffmpegProcess.ExecuteAsync(cancellationToken).ConfigureAwait(false);
-            Cleanup(ffmpegProcess);
+                Task = FFmpegTask.Execute,
+                CustomArguments = argument.Argument
+            };
+            await ExecuteAsync(parameters, output, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task ExecuteAsync(string arguments, CancellationToken cancellationToken)
         {
             var parameters = new FFmpegParameters
             {
+                Task = FFmpegTask.Execute,
                 CustomArguments = arguments,
             };
             await ExecuteAsync(parameters, cancellationToken).ConfigureAwait(false);
         }
         
-        // if further overloads are needed
-        // it should be considered if ExecuteAsync(FFmpegParameters parameters, CancellationToken cancellationToken) should be made public
         public async Task ExecuteAsync(string arguments, string workingDirectory, CancellationToken cancellationToken)
         {
             var parameters = new FFmpegParameters
             {
+                Task = FFmpegTask.Execute,
                 CustomArguments = arguments,
                 WorkingDirectory = workingDirectory
             };
             await ExecuteAsync(parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        // ---------------------------------------------------------
+        // Basic API to call ffmpeg
+        // ---------------------------------------------------------
+
+        public async Task ExecuteAsync(FFmpegParameters parameters, CancellationToken cancellationToken)
+        {
+            var ffmpegProcess = CreateProcess(parameters);
+            await ffmpegProcess.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            Cleanup(ffmpegProcess);
+        }
+
+        public async Task ExecuteAsync(FFmpegParameters parameters, Stream output, CancellationToken cancellationToken)
+        {
+            var outputPipeName = $"{_pipePrefix}{Guid.NewGuid()}";
+            var outputArgument = new OutputPipe(GetPipePath(outputPipeName));
+            var pipe = new NamedPipeServerStream(outputPipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+
+            parameters.Output = outputArgument;
+            var ffmpegProcess = CreateProcess(parameters);
+            try
+            {
+                var executeProcess = ffmpegProcess.ExecuteAsync(cancellationToken);
+                var copyData = pipe.WaitForConnectionAsync(cancellationToken)
+                    .ContinueWith(async x =>
+                    {
+                        await pipe.CopyToAsync(output, cancellationToken);
+                    }, cancellationToken).Unwrap();
+                await Task.WhenAll(executeProcess, copyData).ConfigureAwait(false);
+                pipe.Disconnect();
+            }
+            finally
+            {
+                pipe.Dispose();
+                Cleanup(ffmpegProcess);
+            }
+        }
 
         private FFmpegProcess CreateProcess(FFmpegParameters parameters)
         {

--- a/src/FFmpeg.NET/FFmpegArgumentBuilder.cs
+++ b/src/FFmpeg.NET/FFmpegArgumentBuilder.cs
@@ -9,14 +9,12 @@ namespace FFmpeg.NET
     {
         public static string Build(FFmpegParameters parameters)
         {
-            if (parameters.HasCustomArguments)
-                return parameters.CustomArguments;
-
             return parameters.Task switch
             {
                 FFmpegTask.Convert => Convert(parameters.Input, parameters.Output, parameters.ConversionOptions),
                 FFmpegTask.GetMetaData => GetMetadata(parameters.Input),
                 FFmpegTask.GetThumbnail => GetThumbnail(parameters.Input, parameters.Output, parameters.ConversionOptions),
+                FFmpegTask.Execute => Execute(parameters.Input, parameters.Output, parameters.CustomArguments),
                 _ => throw new ArgumentOutOfRangeException(),
             };
         }
@@ -180,6 +178,28 @@ namespace FFmpeg.NET
                 commandBuilder.AppendFormat(" {0} ", conversionOptions.ExtraArguments);
 
             return commandBuilder.AppendFormat(" {0} ", output.Argument).ToString();
+        }
+
+        private static string Execute(IInputArgument input, IOutputArgument output, string customArguments)
+        {
+            StringBuilder commandBuilder = new StringBuilder();
+            commandBuilder.Append(customArguments);
+
+            if (input != null)
+            {
+                if (input.UseStandardInput)
+                {
+                    commandBuilder.Append(" -nostdin ");
+                }
+                commandBuilder.Append($" -i {input.Argument}");
+            }
+
+            if (output != null)
+            {
+                commandBuilder.Append($"{output.Argument}");
+            }
+
+            return commandBuilder.ToString();
         }
 
         private static void AppendHWAccelOutputFormat(StringBuilder commandBuilder, ConversionOptions conversionOptions)

--- a/src/FFmpeg.NET/FFmpegTask.cs
+++ b/src/FFmpeg.NET/FFmpegTask.cs
@@ -4,6 +4,7 @@
     {
         Convert,
         GetMetaData,
-        GetThumbnail
+        GetThumbnail,
+        Execute
     }
 }


### PR DESCRIPTION
Simplified Engine class to allow for simple addition of wrappers in the future and merged duplicated code.

This is done via two changes to Engine and FFmpegArgumentBuilder:

1.) Made ExecuteAsync methods the base for calling ffmpeg in Engine:
   - Made `Task ExecuteAsync(FFmpegParameters, CancellationToken)` public
   - Added public `Task ExecuteAsync(FFmpegParameters, Stream, CancellationToken)` to stream output (piped)
   - Rewrote wrapper methods (ConvertAsync, etc.) to all call the ExecuteAsync stream/no-stream variants

2.) Added Execute task type to invoke ffpmeg with custom arguments while keeping support for specifying the input and output:
   - Expects CustomArguments to specify operation to perform
   - Has optional input parameter with stdin support (like existing code)
   - Has optional output parameter (used by `ConvertAsync(IArgument, Stream, CancellationToken)` which requires an output pipe)