### PR TITLE
Add FFmpegVersion to event args

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,12 +302,12 @@ private void OnData(object sender, ConversionDataEventArgs e)
 
 private void OnComplete(object sender, ConversionCompleteEventArgs e)
 {
-    Console.WriteLine("Completed conversion from {0} to {1}", e.Input.Name, e.Output.Name);
+    Console.WriteLine("Completed conversion from {0} to {1} (ffmpeg {2})", e.Input.Name, e.Output.Name, e.FFmpegVersion);
 }
 
 private void OnError(object sender, ConversionErrorEventArgs e)
 {
-    Console.WriteLine("[{0} => {1}]: Error: {2}\n{3}", e.Input.Name, e.Output.Name, e.Exception.ExitCode, e.Exception.InnerException);
+    Console.WriteLine("[{0} => {1}]: Error: {2} (ffmpeg {3})\n{4}", e.Input.Name, e.Output.Name, e.Exception.ExitCode, e.FFmpegVersion, e.Exception.InnerException);
 }
 ```
 

--- a/src/FFmpeg.NET/Events/ConversionCompleteEventArgs.cs
+++ b/src/FFmpeg.NET/Events/ConversionCompleteEventArgs.cs
@@ -12,5 +12,6 @@ namespace FFmpeg.NET.Events
 
         public IInputArgument Input { get; }
         public IOutputArgument Output { get; }
+        public string FFmpegVersion { get; init; }
     }
 }

--- a/src/FFmpeg.NET/Events/ConversionDataEventArgs.cs
+++ b/src/FFmpeg.NET/Events/ConversionDataEventArgs.cs
@@ -14,5 +14,6 @@ namespace FFmpeg.NET.Events
         public string Data { get; }
         public IInputArgument Input { get; }
         public IOutputArgument Output { get; }
+        public string FFmpegVersion { get; init; }
     }
 }

--- a/src/FFmpeg.NET/Events/ConversionErrorEventArgs.cs
+++ b/src/FFmpeg.NET/Events/ConversionErrorEventArgs.cs
@@ -15,5 +15,6 @@ namespace FFmpeg.NET.Events
         public FFmpegException Exception { get; }
         public IInputArgument Input { get; }
         public IOutputArgument Output { get; }
+        public string FFmpegVersion { get; init; }
     }
 }

--- a/src/FFmpeg.NET/Events/ConversionProgressEventArgs.cs
+++ b/src/FFmpeg.NET/Events/ConversionProgressEventArgs.cs
@@ -27,6 +27,7 @@ namespace FFmpeg.NET.Events
         public IOutputArgument Output { get; }
         public IInputArgument Input { get; }
         public MediaInfo MediaInfo{ get; }
+        public string FFmpegVersion { get; init; }
 
         public override string ToString()
             => $"[{Input?.Name} => {Output?.Name}]\nFrame: {Frame}\nFps: {Fps}\nSize: {SizeKb}kb\nProcessedDuration: {ProcessedDuration}\nBitrate: {Bitrate}\nTotalDuration: {TotalDuration}";

--- a/src/FFmpeg.NET/FFmpeg.NET.csproj
+++ b/src/FFmpeg.NET/FFmpeg.NET.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <AssemblyName>FFmpeg.NET</AssemblyName>
     <RootNamespace>FFmpeg.NET</RootNamespace>
     <Authors>Tobias Haimerl (cmxl)</Authors>

--- a/src/FFmpeg.NET/FFmpegProcess.cs
+++ b/src/FFmpeg.NET/FFmpegProcess.cs
@@ -17,6 +17,7 @@ namespace FFmpeg.NET
 		private Exception _caughtException;
 
 		private MediaInfo _mediaInfo;
+		private string _ffmpegVersion;
 		private List<string> _messages;
 
 		public FFmpegProcess(FFmpegParameters parameters, string ffmpegFilePath)
@@ -86,12 +87,14 @@ namespace FFmpeg.NET
 			if (_caughtException != null || ffmpegProcess.ExitCode != 0)
 				OnException(_messages, parameters, ffmpegProcess.ExitCode, _caughtException);
 			else
-				OnConversionCompleted(new ConversionCompleteEventArgs(parameters.Input, parameters.Output));
+				OnConversionCompleted(new ConversionCompleteEventArgs(parameters.Input, parameters.Output) { FFmpegVersion = _ffmpegVersion });
 		}
 
 		private void OnDataHandler(object sender, DataReceivedEventArgs e)
 		{
-			OnData(new ConversionDataEventArgs(e.Data, _parameters.Input, _parameters.Output));
+			if (e.Data != null)
+				TryUpdateVersion(e.Data);
+			OnData(new ConversionDataEventArgs(e.Data, _parameters.Input, _parameters.Output) { FFmpegVersion = _ffmpegVersion });
 			FFmpegProcessOnErrorDataReceived(e, _parameters, ref _caughtException, _messages);
 		}
 
@@ -102,11 +105,17 @@ namespace FFmpeg.NET
 					_mediaInfo = newMediaInfo;
 		}
 
+		private void TryUpdateVersion(string data)
+		{
+			if (_ffmpegVersion == null)
+				RegexEngine.IsVersionData(data, out _ffmpegVersion);
+		}
+
 		private void OnException(List<string> messages, FFmpegParameters parameters, int exitCode, Exception caughtException)
 		{
 			var exceptionMessage = GetExceptionMessage(messages);
 			var exception = new FFmpegException(exceptionMessage, caughtException, exitCode);
-			OnConversionError(new ConversionErrorEventArgs(exception, parameters.Input, parameters.Output));
+			OnConversionError(new ConversionErrorEventArgs(exception, parameters.Input, parameters.Output) { FFmpegVersion = _ffmpegVersion });
 		}
 
 		private static string GetExceptionMessage(List<string> messages)
@@ -149,7 +158,7 @@ namespace FFmpeg.NET
 				{
 					if (parameters.Input != null) progressData.TotalDuration = parameters.Input.MetaData?.Duration ?? totalMediaDuration;
 
-					OnProgressChanged(new ConversionProgressEventArgs(progressData, parameters.Input, parameters.Output, _mediaInfo));
+					OnProgressChanged(new ConversionProgressEventArgs(progressData, parameters.Input, parameters.Output, _mediaInfo) { FFmpegVersion = _ffmpegVersion });
 				}
 			}
 			catch (Exception ex)

--- a/src/FFmpeg.NET/IsExternalInit.cs
+++ b/src/FFmpeg.NET/IsExternalInit.cs
@@ -1,0 +1,7 @@
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit { }
+}

--- a/src/FFmpeg.NET/RegexEngine.cs
+++ b/src/FFmpeg.NET/RegexEngine.cs
@@ -29,7 +29,8 @@ namespace FFmpeg.NET
             { Find.AudioFormatHzChannel, new Regex(@"Audio:\s*([^,]*),\s([^,]*),\s([^,]*)") },
             { Find.MetaVideo, new Regex(@"(Stream\s*#[0-9]*:[0-9]*\(?[^\)]*?\)?: Video:.*)") },
             { Find.VideoFormatColorSize, new Regex(@"Video:\s*([^,]*),\s*((?:[^,]*,?[^,]*?)(?:\(.*\))?),\s*(?=[0-9]*x[0-9]*)([0-9]*x[0-9]*)") },
-            { Find.VideoFps, new Regex(@"([0-9\.]*)\s*tbr") }
+            { Find.VideoFps, new Regex(@"([0-9\.]*)\s*tbr") },
+            { Find.Version, new Regex(@"^ffmpeg version\s+(\S+)") }
         };
 
         /// <summary>
@@ -65,6 +66,18 @@ namespace FFmpeg.NET
 
             return true;
         }
+        public static bool IsVersionData(string data, out string version)
+        {
+            version = null;
+            if (string.IsNullOrEmpty(data)) return false;
+
+            var match = _index[Find.Version].Match(data);
+            if (!match.Success) return false;
+
+            version = match.Groups[1].Value;
+            return true;
+        }
+
         internal static bool IsMediaInfo(string data, out MediaInfo mediaInfo)
         {
             mediaInfo = null;
@@ -208,7 +221,8 @@ namespace FFmpeg.NET
             MetaVideo,
             BitRate,
             VideoFormatColorSize,
-            VideoFps
+            VideoFps,
+            Version
         }
     }
 }

--- a/tests/FFmpeg.NET.Tests/BugVerificationTests.cs
+++ b/tests/FFmpeg.NET.Tests/BugVerificationTests.cs
@@ -37,7 +37,12 @@ namespace FFmpeg.NET.Tests
             var outputStream = new MemoryStream();
 
             bool dataEventFired = false;
-            engine.Data += (s, e) => dataEventFired = true;
+            string ffmpegVersion = null;
+            engine.Data += (s, e) =>
+            {
+                dataEventFired = true;
+                ffmpegVersion ??= e.FFmpegVersion;
+            };
 
             await engine.ConvertAsync(_fixture.VideoFile, outputStream, options, CancellationToken.None);
 
@@ -45,6 +50,8 @@ namespace FFmpeg.NET.Tests
 
             Assert.True(outputStream.Length > 0, "Pipe conversion should produce output data");
             Assert.True(dataEventFired, "Engine Data events should fire during conversion");
+            Assert.NotNull(ffmpegVersion);
+            Assert.NotEmpty(ffmpegVersion);
         }
 
         /// <summary>
@@ -83,7 +90,12 @@ namespace FFmpeg.NET.Tests
             var input = _fixture.VideoFile;
 
             FFmpegException capturedException = null;
-            engine.Error += (s, e) => capturedException = e.Exception;
+            string ffmpegVersion = null;
+            engine.Error += (s, e) =>
+            {
+                capturedException = e.Exception;
+                ffmpegVersion = e.FFmpegVersion;
+            };
 
             await engine.ConvertAsync(input, output, default);
 
@@ -94,6 +106,8 @@ namespace FFmpeg.NET.Tests
 
             // The two stderr lines should now be separated by a newline
             Assert.Contains(Environment.NewLine, capturedException.Message);
+            Assert.NotNull(ffmpegVersion);
+            Assert.NotEmpty(ffmpegVersion);
         }
 
         /// <summary>

--- a/tests/FFmpeg.NET.Tests/ConversionTests.cs
+++ b/tests/FFmpeg.NET.Tests/ConversionTests.cs
@@ -69,6 +69,8 @@ namespace FFmpeg.NET.Tests
             Assert.Equal(e.Sender, ffmpeg);
             Assert.Equal(_fixture.VideoFile.FileInfo.FullName, e.Arguments.Input.Name);
             Assert.Equal(output.FileInfo.FullName, e.Arguments.Output.Name);
+            Assert.NotNull(e.Arguments.FFmpegVersion);
+            Assert.NotEmpty(e.Arguments.FFmpegVersion);
         }
 
         [Fact]
@@ -89,6 +91,8 @@ namespace FFmpeg.NET.Tests
             Assert.Equal(input, e.Arguments.Input);
             Assert.Equal(output, e.Arguments.Output);
             Assert.Equal(1, e.Arguments.Exception.ExitCode);
+            Assert.NotNull(e.Arguments.FFmpegVersion);
+            Assert.NotEmpty(e.Arguments.FFmpegVersion);
         }
 
         [Fact]
@@ -139,6 +143,8 @@ namespace FFmpeg.NET.Tests
             Assert.Equal(e.Sender, ffmpeg);
             Assert.Equal(_fixture.VideoFile.FileInfo.FullName, e.Arguments.Input.Name);
             Assert.Equal(output.FileInfo.FullName, e.Arguments.Output.Name);
+            Assert.NotNull(e.Arguments.FFmpegVersion);
+            Assert.NotEmpty(e.Arguments.FFmpegVersion);
         }
 
         [Fact]
@@ -161,6 +167,8 @@ namespace FFmpeg.NET.Tests
             Assert.Equal(e.Sender, ffmpeg);
             Assert.Equal(_fixture.VideoFile.FileInfo.FullName, e.Arguments.Input.Name);
             Assert.Equal(output.FileInfo.FullName, e.Arguments.Output.Name);
+            Assert.NotNull(e.Arguments.FFmpegVersion);
+            Assert.NotEmpty(e.Arguments.FFmpegVersion);
         }
 
         [Fact]

--- a/tests/FFmpeg.NET.Tests/MetadataTests.cs
+++ b/tests/FFmpeg.NET.Tests/MetadataTests.cs
@@ -110,6 +110,32 @@ namespace FFmpeg.NET.Tests
         }
 
         [Theory]
+        [InlineData("ffmpeg version 4.4.2 Copyright (c) 2000-2021 the FFmpeg developers", "4.4.2")]
+        [InlineData("ffmpeg version 6.1.1 Copyright (c) 2000-2023 the FFmpeg developers", "6.1.1")]
+        [InlineData("ffmpeg version N-112057-g880c1cd Copyright (c) 2000-2023 the FFmpeg developers", "N-112057-g880c1cd")]
+        [InlineData("ffmpeg version 2024-01-15-git-5765aeb592-full_build-www.gyan.dev Copyright (c) 2000-2024 the FFmpeg developers", "2024-01-15-git-5765aeb592-full_build-www.gyan.dev")]
+        public void RegexEngine_Can_Parse_Version(string data, string expectedVersion)
+        {
+            var result = RegexEngine.IsVersionData(data, out var version);
+
+            Assert.True(result);
+            Assert.Equal(expectedVersion, version);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("Duration: 00:00:05.31, start: 0.000000, bitrate: 1589 kb/s")]
+        [InlineData("Stream #0:0(und): Video: h264")]
+        public void RegexEngine_Returns_False_For_NonVersion_Data(string data)
+        {
+            var result = RegexEngine.IsVersionData(data, out var version);
+
+            Assert.False(result);
+            Assert.Null(version);
+        }
+
+        [Theory]
         [InlineData("Stream #0:0(und): Video: h264 (Main) (avc1 / 0x31637661), yuv420p, 1280x720 [SAR 1:1 DAR 16:9], 1205 kb/s, 25 fps, 25 tbr, 12800 tbn, 50 tbc (default)", 1205, "yuv420p", "1280x720", "h264 (Main) (avc1 / 0x31637661)")]
         [InlineData("Stream #0:0(und): Video: hevc (Main 10) (hvc1 / 0x31637668), yuv420p10le(tv, bt2020/arib-std-b67, progressive), 1920x1080, 8517 kb/s, 29.98 fps, 29.97 tbr, 600 tbn, 600 tbc (default)", 8517, "yuv420p10le(tv, bt2020/arib-std-b67, progressive)", "1920x1080", "hevc (Main 10) (hvc1 / 0x31637668)")]
         public void RegexEngine_Can_Read_Video_MetaData(string data, int bitrate, string colorModel, string frameSize, string format)


### PR DESCRIPTION
## Summary
- Parse FFmpeg version from the stderr banner during execution and expose
  it as `FFmpegVersion` on all four event args types
- No separate process call needed — version comes from the same FFmpeg
  invocation that does the work, avoiding TOCTOU issues
- Returns `null` when `-hide_banner` is used

## Changes
- `RegexEngine` — new `Version` regex and `IsVersionData()` method
- `FFmpegProcess` — captures version from first stderr line before firing events
- All event args — new `string FFmpegVersion { get; init; }` property
- `IsExternalInit.cs` polyfill + `LangVersion 9.0` for `init` on netstandard2.1
- 8 new unit tests for version parsing (positive + negative cases)
- Version assertions added to existing event tests
- README updated with version in event handler examples

## Test plan
- [x] All 39 tests pass
- [x] Regex tests cover: standard versions, nightly builds, git hashes, custom builds
- [x] Negative regex tests cover: null, empty, non-version stderr lines
- [x] Version verified on Complete, Error, Progress, and Data events